### PR TITLE
Base VRCT_Trigger on VRC_UseEvents

### DIFF
--- a/VRCT_Trigger.cs
+++ b/VRCT_Trigger.cs
@@ -4,7 +4,7 @@ using VRCSDK2;
 
 namespace CameraPlus
 {
-    class VRCT_Trigger : VRC_Interactable
+    class VRCT_Trigger : VRC_UseEvents
     {
         private Action onInteract;
 


### PR DESCRIPTION
Pros: button outlines are back
Cons: it can break in the update that removes the obsolete VRC_UseEvents. It would be easy enough to revert back to VRC_Interactable in that case.

Based on my reading of VRC code, this should be reasonably safe - that is, VRC_UseEvents sends network events in Interact method which is overridden in VRCT_Trigger. I didn't find any other suspicious uses of VRC_UseEvents that are linked to network activity in the codebase either.